### PR TITLE
Handle multi-line error messages from require

### DIFF
--- a/lib/store.js
+++ b/lib/store.js
@@ -22,7 +22,7 @@ function(path, _, optimist, callsite, is_path_absolute, get_set) {
 		}
 		catch(err) {
 			if (   err.code === 'MODULE_NOT_FOUND'
-				 && err.message.slice(-file_path.length-1, -1) === file_path) {
+				 && err.message.split('\n', 1)[0].slice(-file_path.length-1, -1) === file_path) {
 				// we tried to import an non-existing file
 				// swallow the error, this is expected.
 			}


### PR DESCRIPTION
Since Node.js 12 the "MODULE_NOT_FOUND" error thrown by `require` has a "require stack" appended to its message. This change in behavior results in a message being printed to stderr for example when "config.development.local.json" does not exist.

See nodejs/node#25690.